### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from distutils.command.build import build
 from setuptools import setup
 from os import path
 import platform


### PR DESCRIPTION
I got this warning and *distutils* doesn't seem necessary.
```
setuptools/distutils_patch.py:25: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
```